### PR TITLE
Use built-in json decoding for DAP launch configs

### DIFF
--- a/after/plugin/dap-launch-json.lua
+++ b/after/plugin/dap-launch-json.lua
@@ -1,5 +1,3 @@
-local json = require("lunajson")
-
 local function load_launch_json()
   local file_path = vim.fn.getcwd() .. "/.vscode/launch.json"
   local file = io.open(file_path, "r")
@@ -12,7 +10,7 @@ local function load_launch_json()
   local content = file:read("*a")
   file:close()
 
-  local ok, parsed = pcall(json.decode, content)
+  local ok, parsed = pcall(vim.fn.json_decode, content)
   if not ok then
     print("Error parsing launch.json: " .. parsed)
     return


### PR DESCRIPTION
## Summary
- remove external lunajson dependency
- use `vim.fn.json_decode` to read launch.json for DAP

## Testing
- `XDG_DATA_HOME=/tmp/nvim nvim -Es -u /tmp/mini-init2.lua -c q`


------
https://chatgpt.com/codex/tasks/task_e_684ecaa89e80832485e47336d9e4e77a